### PR TITLE
Support CentOS6

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
+        - 6
         - 7
     - name: Ubuntu
       versions:

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -3,14 +3,12 @@
 - name: requirements for Python install
   block:
 
-    - name: install addtional repos
+    - name: install IUS repo
       become: true
       yum:
-        name: "{{ item }}"
+        name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
         state: present
         update_cache: true
-      with_items:
-        - https://centos7.iuscommunity.org/ius-release.rpm
 
     - name: install system packages
       become: true


### PR DESCRIPTION
This points at the appropriate repo for the given CentOS version. Currently, only 6 and 7 are supported although I'd expect any future version 8 may be supported in the same way.