### PR TITLE
Add soft link to Python3 on CentOS

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -21,14 +21,21 @@
         - python36u
         - python36u-devel
         - python36u-pip
-    
+
     - name: install pip
       become: true
-      command: "{{ python3_command }} -m ensurepip"            
-                
+      command: "{{ python3_command }} -m ensurepip"
+
+    - name: add soft link to python3
+      become: true
+      file:
+        src: /usr/bin/python3.6
+        dest: /usr/bin/python3
+        state: link
+
   when: python3_pyenv == None
-      
-      
+
+
 - name: requirements for pyenv install
   block:
 


### PR DESCRIPTION
This is in support of various things that may assume there is a python3 executable (like virtualenv). I've added it to CentOS as it's not clear to me if paths are the same on Ubuntu.

I don't think this will cause any conflicts or issues with anything else. I wouldn't be opposed to having this controlled by a variable defaulting to "don't" though.

(I've also removed several sets of trailing spaces.)